### PR TITLE
Default value for grub_tpl_default_kernel_params

### DIFF
--- a/templates/etc/default/grub.j2
+++ b/templates/etc/default/grub.j2
@@ -6,6 +6,7 @@
 #   info -f grub -n 'Simple configuration'
 
 {% set grub_tpl_local_kernel_options = [] %}
+{% set grub_tpl_default_kernel_params = [] %}
 {% if ansible_local|d() and ansible_local.grub|d() and ansible_local.grub.kernel_options|d() %}
 {% set grub_tpl_local_kernel_options = ansible_local.grub.kernel_options %}
 {% endif %}


### PR DESCRIPTION
When grub_save_options was false task "Configure /etc/default/grub"
was failing because grub_tpl_default_kernel_params was undefined.