### PR TITLE
Configuration option for the GRUB_TERMINAL

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -60,6 +60,12 @@ grub_timeout_hardware: 5
 grub_timeout_virtual: 1
 
 
+# .. envvar:: grub_terminal
+#
+# GRUB terminal(s) to use. Set to false to use the platform
+# specific default.
+grub_terminal: '{{ "serial console" if grub_serial_console else False }}'
+
 # .. envvar:: grub_custom_options
 #
 # Additional GRUB options specified as a YAML text block.

--- a/templates/etc/default/grub.j2
+++ b/templates/etc/default/grub.j2
@@ -47,8 +47,12 @@ GRUB_CMDLINE_LINUX="{{ grub_tpl_kernel_params | join(' ') }}"
 # the memory map information from GRUB (GNU Mach, kernel of FreeBSD ...)
 #GRUB_BADRAM="0x01234567,0xfefefefe,0x89abcdef,0xefefefef"
 
+{% if grub_terminal %}
+GRUB_TERMINAL="{{ grub_terminal }}"
+{% else %}
 # Uncomment to disable graphical terminal (grub-pc only)
 #GRUB_TERMINAL=console
+{% endif %}
 
 # The resolution used on graphical terminal
 # note that you can use only modes which your graphic card supports via VBE
@@ -65,7 +69,6 @@ GRUB_CMDLINE_LINUX="{{ grub_tpl_kernel_params | join(' ') }}"
 #GRUB_INIT_TUNE="480 440 1"
 {% if grub_serial_console %}
 
-GRUB_TERMINAL="serial console"
 GRUB_SERIAL_COMMAND="serial --unit={{ grub_serial_console_unit }} --speed={{ grub_serial_console_speed }} --word=8 --parity=no --stop=1"
 {% endif %}
 {% if grub_users_combined|length > 0 and grub_menuentry_access is string %}


### PR DESCRIPTION
The default graphical terminal does not work on some systems. So allow
this to be configured without also enabling the serial console. This
preserves the previous defaults.