### PR TITLE
Configuration option to set the GRUB_HIDDEN_TIMEOUT

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -59,6 +59,17 @@ grub_timeout_hardware: 5
 # GRUB timeout for virtual devices.
 grub_timeout_virtual: 1
 
+# .. envvar:: grub_hidden_timeout
+#
+# GRUB timeout to wait for a key to be pressed to show the menu.
+# Set to false to not set a hidden timeout and show the menu
+# without pressing a key first.
+grub_hidden_timeout: '{{ 0 if ansible_distribution in ["Ubuntu"] else False }}'
+
+# .. envvar:: grub_hidden_timeout_quiet
+#
+# Suppress the countdown while waiting for a key to show the menu.
+grub_hidden_timeout_quiet: 'true'
 
 # .. envvar:: grub_custom_options
 #

--- a/templates/etc/default/grub.j2
+++ b/templates/etc/default/grub.j2
@@ -29,9 +29,9 @@
 {%   set _ = grub_tpl_kernel_params.append('console=ttyS{},{}n8'.format(grub_serial_console_unit,grub_serial_console_speed)) %}
 {% endif %}
 GRUB_DEFAULT={{ grub_tpl_default }}
-{% if ansible_distribution in [ 'Ubuntu' ] %}
-GRUB_HIDDEN_TIMEOUT=0
-GRUB_HIDDEN_TIMEOUT_QUIET=true
+{% if grub_hidden_timeout %}
+GRUB_HIDDEN_TIMEOUT={{ grub_hidden_timeout }}
+GRUB_HIDDEN_TIMEOUT_QUIET={{ grub_hidden_timeout_quiet }}
 {% endif %}
 {% if ansible_virtualization_role is undefined or ansible_virtualization_role not in [ 'guest' ] %}
 GRUB_TIMEOUT={{ grub_timeout_hardware }}


### PR DESCRIPTION
Previously this was enabled unconditionally on Ubuntu and unset on
other systems. These two configuration options allow configuring the
hidden timeout on all systems while preserving the current default
values.

This is especially usefull if you don't want the hidden timeout on Ubuntu systems. Something which is impossible with the current role.