### PR TITLE
fixed deprecation warning for 'always_run: True'

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,7 +11,7 @@ galaxy_info:
   description: 'Manage GRUB configuration'
   company: 'DebOps'
   license: 'GPLv3'
-  min_ansible_version: '1.7.1'
+  min_ansible_version: '2.2.0'
   platforms:
     - name: Ubuntu
       versions:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,14 +14,14 @@
   shell: test -f /etc/default/grub.dpkg-divert && . /etc/default/grub.dpkg-divert || . /etc/default/grub ; echo $GRUB_CMDLINE_LINUX_DEFAULT | tr " " "\n"
   register: grub_register_default_cmdline
   changed_when: False
-  always_run: True
+  check_mode: no
   when: grub_save_options
 
 - name: Get old kernel parameters
   shell: test -f /etc/default/grub.dpkg-divert && . /etc/default/grub.dpkg-divert || . /etc/default/grub ; echo $GRUB_CMDLINE_LINUX | tr " " "\n"
   register: grub_register_old_cmdline
   changed_when: False
-  always_run: True
+  check_mode: no
   when: grub_save_options
 
 - name: Default kernel parameters


### PR DESCRIPTION
fixed deprecation warning for `always_run: True` and substituted it with `check_mode: no` as `check_mode: no` was introduced with ansible 2.2 also the meta description now requires at least ansible version 2.2.0