### PR TITLE
always_run is deprecated. Use check_mode = no instead..

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,8 @@ Fixed
 
 - Fix deprecation warnings in Ansible 2.1.0. [ypid_]
 
+- Fix Ansible 2.2 deprecation warnings. [brzhk]
+
 - Fix password protection feature which was broken with Ansible 2.1 and above
   because of changes how ``\n`` is handled by Jinja. [Polichronucci, ypid_]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,7 +33,8 @@ Fixed
 
 - Fix deprecation warnings in Ansible 2.1.0. [ypid_]
 
-- Fix Ansible 2.2 deprecation warnings which requires Ansible 2.2 or higher. Support for older Ansible versions is dropped. [brzhk]
+- Fix Ansible 2.2 deprecation warnings which requires Ansible 2.2 or higher.
+  Support for older Ansible versions is dropped. [brzhk]
 
 - Fix password protection feature which was broken with Ansible 2.1 and above
   because of changes how ``\n`` is handled by Jinja. [Polichronucci, ypid_]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,7 +33,7 @@ Fixed
 
 - Fix deprecation warnings in Ansible 2.1.0. [ypid_]
 
-- Fix Ansible 2.2 deprecation warnings. [brzhk]
+- Fix Ansible 2.2 deprecation warnings which requires Ansible 2.2 or higher. Support for older Ansible versions is dropped. [brzhk]
 
 - Fix password protection feature which was broken with Ansible 2.1 and above
   because of changes how ``\n`` is handled by Jinja. [Polichronucci, ypid_]

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   description: 'Manage GRUB configuration'
   company: 'DebOps'
   license: 'GPL-3.0'
-  min_ansible_version: '2.1.4'
+  min_ansible_version: '2.2.0'
   platforms:
     - name: Ubuntu
       versions:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,14 +10,14 @@
   shell: test -f /etc/default/grub.dpkg-divert && . /etc/default/grub.dpkg-divert || . /etc/default/grub ; echo $GRUB_CMDLINE_LINUX_DEFAULT | tr " " "\n"
   register: grub_register_default_cmdline
   changed_when: False
-  check_mode: no
+  check_mode: False
   when: grub_save_options
 
 - name: Get old kernel parameters
   shell: test -f /etc/default/grub.dpkg-divert && . /etc/default/grub.dpkg-divert || . /etc/default/grub ; echo $GRUB_CMDLINE_LINUX | tr " " "\n"
   register: grub_register_old_cmdline
   changed_when: False
-  check_mode: no
+  check_mode: False
   when: grub_save_options
 
 - name: Default kernel parameters

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,14 +10,14 @@
   shell: test -f /etc/default/grub.dpkg-divert && . /etc/default/grub.dpkg-divert || . /etc/default/grub ; echo $GRUB_CMDLINE_LINUX_DEFAULT | tr " " "\n"
   register: grub_register_default_cmdline
   changed_when: False
-  always_run: True
+  check_mode: no
   when: grub_save_options
 
 - name: Get old kernel parameters
   shell: test -f /etc/default/grub.dpkg-divert && . /etc/default/grub.dpkg-divert || . /etc/default/grub ; echo $GRUB_CMDLINE_LINUX | tr " " "\n"
   register: grub_register_old_cmdline
   changed_when: False
-  always_run: True
+  check_mode: no
   when: grub_save_options
 
 - name: Default kernel parameters


### PR DESCRIPTION
[DEPRECATION WARNING]: always_run is deprecated. Use check_mode = no instead..
This feature will be removed in version 2.4. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.